### PR TITLE
Add permissions check to comments form

### DIFF
--- a/app/views/spree/admin/shared/_comments.html.erb
+++ b/app/views/spree/admin/shared/_comments.html.erb
@@ -6,37 +6,39 @@
   </div>
 <% end %>
 
-<div class="order-add-comment">
-  <%= form_for(:comment, :url => admin_comments_url) do |f| %>
-    <%= hidden_field_tag 'comment[commentable_id]', commentable.id %>
-    <%= hidden_field_tag 'comment[commentable_type]', commentable.class %>
-    <%= hidden_field_tag 'comment[user_id]', spree_current_user.id %>
+<% if can? :create, commentable.comments.build %>
+  <div class="order-add-comment">
+    <%= form_for(:comment, :url => admin_comments_url) do |f| %>
+      <%= hidden_field_tag 'comment[commentable_id]', commentable.id %>
+      <%= hidden_field_tag 'comment[commentable_type]', commentable.class %>
+      <%= hidden_field_tag 'comment[user_id]', spree_current_user.id %>
 
-    <fieldset data-hook="admin_comment_form_fields" class="no-border-top fullwidth">
-      <fieldset class="index no-border-bottom">
-        <legend align="center"><%= Spree.t(:add_comment) %></legend>
+      <fieldset data-hook="admin_comment_form_fields" class="no-border-top fullwidth">
+        <fieldset class="index no-border-bottom">
+          <legend align="center"><%= Spree.t(:add_comment) %></legend>
 
-        <div data-hook="comment_fields" class="row">
-          <div class="alpha twelve columns">
-            <% if @comment_types.present? %>
+          <div data-hook="comment_fields" class="row">
+            <div class="alpha twelve columns">
+              <% if @comment_types.present? %>
+                <div class="field">
+                  <%= f.label :comment_type_id, Spree.t(:type) %>
+                  <%= f.select :comment_type_id, @comment_types.map{|ct| [ct.name, ct.id]},{} ,:class => 'fullwidth' %>
+                </div>
+              <% end %>
               <div class="field">
-                <%= f.label :comment_type_id, Spree.t(:type) %>
-                <%= f.select :comment_type_id, @comment_types.map{|ct| [ct.name, ct.id]},{} ,:class => 'fullwidth' %>
+                <%= f.label :comment, Spree.t(:comment) %>
+                <%= f.text_area :comment, :style => 'height:150px;', :class => 'fullwidth' %>
               </div>
-            <% end %>
-            <div class="field">
-              <%= f.label :comment, Spree.t(:comment) %>
-              <%= f.text_area :comment, :style => 'height:150px;', :class => 'fullwidth' %>
             </div>
           </div>
+        </fieldset>
+
+        <div class="clear"></div>
+
+        <div class="form-buttons filter-actions actions" data-hook="buttons">
+          <%= f.submit Spree.t(:add_comment) %>
         </div>
       </fieldset>
-
-      <div class="clear"></div>
-
-      <div class="form-buttons filter-actions actions" data-hook="buttons">
-        <%= button Spree.t(:add_comment), 'icon-arrow-right' %>
-      </div>
-    </fieldset>
-  <% end %>
-</div>
+    <% end %>
+  </div>
+<% end %>


### PR DESCRIPTION
We should only display the comment form if the user has permissions
to comment on the commentable object.